### PR TITLE
Fix wrapper.conf getting overwritten after amc_setup is run.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.1
+
+* wrapper.conf template only runs once to avoid erasing ARM settings after amc_setup.
+
 # 0.6.0
 
 * Change Lightweight Resource Provider to Custom Resource.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'reed@hoegg.software'
 license          'Apache License, Version 2.0'
 description      'Installs/Configures Mule ESB'
 long_description 'Installs/Configures Mule ESB'
-version          '0.6.0'
+version          '0.6.1'
 
 supports 'ubuntu'
 depends 'compat_resource'

--- a/resources/ubuntu.rb
+++ b/resources/ubuntu.rb
@@ -30,14 +30,14 @@ action :create do
         end
 
         install_upstart_service
-        
+
         start_service
     else
         install_community_runtime
         update_wrapper
 
         install_upstart_service
-            
+
         start_service
     end
 end
@@ -186,6 +186,12 @@ action_class.class_eval do
                 init_heap_size: new_resource.init_heap_size,
                 max_heap_size: new_resource.max_heap_size
             )
+            action :nothing
+        end
+
+        file "#{new_resource.home}/conf/wrapper.conf.lock" do
+            action :create_if_missing
+            notifies :create, "template[#{new_resource.home}/conf/wrapper.conf]", :immediately
         end
     end
 


### PR DESCRIPTION
This is a crappy fix, but will do for now. A wrapper.conf.lock file is created, to indicate wrapper.conf has been set by Chef. If wrapper.conf needs to be rewritten, delete the wrapper.conf.lock.
