### PR TITLE
Fix low memory for cloud testing.

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -1,14 +1,14 @@
 ---
 driver:
   name: digitalocean
-  customize:
-    memory: 4096
 
 provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-14.04
+  - name: ubuntu-14-04-x64
+    driver_config:
+      size: 2gb
 
 suites:
   - name: default

--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -2,8 +2,7 @@
 driver:
   name: digitalocean
   customize:
-    memory: 2048
-    cpuexecutioncap: 50
+    memory: 4096
 
 provisioner:
   name: chef_zero


### PR DESCRIPTION
Was using wrong syntax for the kitchen-digitalocean driver.
