### PR TITLE
Corrected "can't modify frozen Array" when running Chef 13.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+
+# Eclipse
+.project

--- a/resources/centos.rb
+++ b/resources/centos.rb
@@ -13,7 +13,7 @@ property :home, String, default: '/usr/local/mule-esb'
 property :env, String, default: 'test'
 property :init_heap_size, String, default: '1024'
 property :max_heap_size, String, default: '1024'
-property :wrapper_additional, Array, default: []
+property :wrapper_additional, Array, default: lazy{ [] }
 property :wrapper_defaults, [TrueClass, FalseClass], default: true
 property :amc_setup, String, default: ''
 

--- a/resources/ubuntu.rb
+++ b/resources/ubuntu.rb
@@ -12,7 +12,7 @@ property :home, String, default: '/usr/local/mule-esb'
 property :env, String, default: 'test'
 property :init_heap_size, String, default: '1024'
 property :max_heap_size, String, default: '1024'
-property :wrapper_additional, Array, default: []
+property :wrapper_additional, Array, default: lazy{ [] }
 property :wrapper_defaults, [TrueClass, FalseClass], default: true
 property :amc_setup, String, default: ''
 


### PR DESCRIPTION
Corrected Chef 13 compatibility issue #23. This was simply done by following the straight-forward instructions from Chef 13 Releases Notes to add a lzay{} helper: https://docs.chef.io/release_notes.html#default-values-for-resource-properties-are-frozen

I tested for both Ubuntu and CentOS with Chef 13, compatibility with Chef 12 should not cause any issue but it remains to be tested properly