### PR TITLE
Added mule-test attribute to run Kitchen tests with CE or EE

### DIFF
--- a/test/cookbooks/mule-test/attributes/default.rb
+++ b/test/cookbooks/mule-test/attributes/default.rb
@@ -4,3 +4,5 @@ default['java']['oracle']['accept_oracle_download_terms'] = true
 
 default['mule-test']['user'] = 'mule'
 default['mule-test']['group'] = 'mule'
+  
+default['mule-test']['enterprise'] = true

--- a/test/cookbooks/mule-test/recipes/default.rb
+++ b/test/cookbooks/mule-test/recipes/default.rb
@@ -1,11 +1,18 @@
 directory '/tmp/mule'
 
-aws_s3_file '/tmp/mule/mule-ee-distribution-standalone-3.8.0.zip' do
-    bucket 'hoegg-ci-data'
-    remote_path 'installs/mule-ee-distribution-standalone-3.8.0.zip'
-    aws_access_key node['aws']['access_key']
-    aws_secret_access_key node['aws']['secret']
-    not_if do ::File.exists?('/tmp/mule/mule-ee-distribution-standalone-3.8.0.zip') end
+if node['mule-test']['enterprise']
+  aws_s3_file '/tmp/mule/mule-ee-distribution-standalone-3.8.0.zip' do
+      bucket 'hoegg-ci-data'
+      remote_path 'installs/mule-ee-distribution-standalone-3.8.0.zip'
+      aws_access_key node['aws']['access_key']
+      aws_secret_access_key node['aws']['secret']
+      not_if do ::File.exists?('/tmp/mule/mule-ee-distribution-standalone-3.8.0.zip') end
+  end
+else
+  remote_file "/tmp/mule/mule-standalone-3.8.0.zip" do
+    source 'https://repository-master.mulesoft.org/nexus/content/repositories/releases/org/mule/distributions/mule-standalone/3.8.0/mule-standalone-3.8.0.zip'
+    action :create
+  end
 end
 
 group node['mule-test']['group'] do
@@ -22,7 +29,7 @@ end
 include_recipe 'java::default'
 
 mule_instance 'mule-esb' do
-    enterprise_edition true
+    enterprise_edition node['mule-test']['enterprise']
     home '/usr/local/mule-esb-test'
     env 'test'
     user node['mule-test']['user']
@@ -31,7 +38,7 @@ mule_instance 'mule-esb' do
 end
 
 mule_instance 'mule-esb-2' do
-    enterprise_edition true
+    enterprise_edition node['mule-test']['enterprise']
     home '/usr/local/mule-esb-test-2'
     env 'test'
     user node['mule-test']['user']


### PR DESCRIPTION
Mainly working with Mule CE and regularly contributing to this cookbook, I thought it would be useful to be able to run Kitchen tests locally with CE without requiring extra configs and workaround. Currently tests are hard-coded to run Mule EE using secrets from environment variables, preventing any external contributor from running their tests locally. 

This wat any contributor can run tests locally with Mule CE by simply specifying this attribute in their `.kitchen.local.yml`:

```
attributes:
     mule-test:
       enterprise: false
```

This does not impact existing tests: they still use Mule EE and should run as usual.